### PR TITLE
Milan Schema Convertor To SharedTree LLS

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -48,6 +48,7 @@
 		"@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+		"@fluid-internal/tree": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"axios": "^0.26.0",
 		"buffer": "^6.0.3",
 		"fastest-json-copy": "^1.0.1",

--- a/experimental/PropertyDDS/packages/property-dds/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/index.ts
@@ -22,3 +22,4 @@ export {
 	LZ4PropertyTreeFactory,
 } from "./propertyTreeExtFactories";
 export { PropertyTreeFactory } from "./propertyTreeFactory";
+export { convertSchemaToSharedTreeLls } from "./sharedtree/";

--- a/experimental/PropertyDDS/packages/property-dds/src/sharedtree/index.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/sharedtree/index.ts
@@ -1,0 +1,5 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+export { convertSchemaToSharedTreeLls } from "./llsSchemaConverter";

--- a/experimental/PropertyDDS/packages/property-dds/src/sharedtree/llsSchemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/sharedtree/llsSchemaConverter.ts
@@ -1,0 +1,314 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+import { fail } from "assert";
+import {
+	brand,
+	emptyField,
+	EmptyKey,
+	FieldKindIdentifier,
+	FieldSchema,
+	LocalFieldKey,
+	rootFieldKey,
+	SchemaData,
+	TreeSchema,
+	TreeSchemaIdentifier,
+	ValueSchema,
+	FullSchemaPolicy,
+} from "@fluid-internal/tree";
+import { PropertyFactory, PropertyTemplate } from "@fluid-experimental/property-properties";
+import { TypeIdHelper } from "@fluid-experimental/property-changeset";
+
+const booleanTypes = new Set(["Bool"]);
+const numberTypes = new Set([
+	"Int8",
+	"Uint8",
+	"Int16",
+	"Uint16",
+	"Int32",
+	"Int64",
+	"Uint64",
+	"Uint32",
+	"Float32",
+	"Float64",
+	"Enum",
+]);
+const primitiveTypes = new Set([
+	"Bool",
+	"String",
+	"Int8",
+	"Uint8",
+	"Int16",
+	"Uint16",
+	"Int32",
+	"Int64",
+	"Uint64",
+	"Uint32",
+	"Float32",
+	"Float64",
+	"Enum",
+]);
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type Context = {
+	typeid: TreeSchemaIdentifier;
+	context: string;
+	types?: Set<TreeSchemaIdentifier>;
+};
+
+function isIgnoreNestedProperties(typeid: string): boolean {
+	return typeid === "Enum";
+}
+
+export function convertSchemaToSharedTreeLls(
+	policy: FullSchemaPolicy,
+	rootFieldSchema: FieldSchema,
+): SchemaData {
+	const [ValueFieldKind, OptionalFieldKind, SequenceFieldKind] = policy.fieldKinds.keys();
+	const treeSchema = new Map();
+	const rootTypes = rootFieldSchema.types ?? fail("Expected root types");
+
+	// Extract all referenced typeids for the schema
+	const unprocessedTypeIds: string[] = [...rootTypes];
+	const referencedTypeIDs = new Map<TreeSchemaIdentifier, Context>();
+
+	while (unprocessedTypeIds.length > 0) {
+		const unprocessedTypeID = unprocessedTypeIds.pop() ?? fail("fail");
+
+		const context: Context = {
+			typeid: brand(unprocessedTypeID),
+			context: "single",
+		};
+		referencedTypeIDs.set(brand(unprocessedTypeID), context);
+
+		const schemaTemplate = PropertyFactory.getTemplate(unprocessedTypeID);
+		if (schemaTemplate === undefined) {
+			throw new Error(`Unknown typeid: ${unprocessedTypeID}`);
+		}
+		const dependencies = PropertyTemplate.extractDependencies(
+			schemaTemplate,
+		) as TreeSchemaIdentifier[];
+		for (const dependencyTypeId of dependencies) {
+			if (!referencedTypeIDs.has(dependencyTypeId)) {
+				unprocessedTypeIds.push(dependencyTypeId);
+			}
+		}
+
+		// Extract context information (i.e. array, map and set types)
+		const extractContexts = (properties: any[]): void => {
+			for (const property of properties || []) {
+				if (property.properties) {
+					// We have a nested set of properties
+					// TODO: We have to create a corresponding nested type
+					extractContexts(property.properties);
+				}
+				if (property.context !== undefined && property.context !== "single") {
+					referencedTypeIDs.set(brand(`${property.context}<${property.typeid}>`), {
+						typeid: property.typeid,
+						context: property.context,
+					});
+				}
+				if (TypeIdHelper.isPrimitiveType(property.typeid)) {
+					referencedTypeIDs.set(property.typeid, {
+						typeid: property.typeid,
+						context: "single",
+					});
+				}
+			}
+		};
+		extractContexts(schemaTemplate.properties);
+	}
+
+	for (const type of primitiveTypes) {
+		const typeid: TreeSchemaIdentifier = brand(type);
+		if (!referencedTypeIDs.has(typeid)) {
+			referencedTypeIDs.set(typeid, {
+				typeid,
+				context: "single",
+			});
+		}
+	}
+
+	// Now we create the actual schemas, since we are now able to reference the dependent types
+	for (const [referencedTypeId, context] of referencedTypeIDs) {
+		if (treeSchema.get(referencedTypeId) !== undefined) {
+			continue;
+		}
+		let typeSchema: TreeSchema | undefined;
+
+		if (context.context === "single") {
+			if (TypeIdHelper.isPrimitiveType(referencedTypeId)) {
+				// if (context.typeid === "String") {
+				//     // String is a special case, we actually have to represent it as a sequence
+				//     typeSchema = {
+				//         localFields: new Map<LocalFieldKey, FieldSchema>([
+				//             [
+				//                 EmptyKey,
+				//                 {
+				//                     kind: fieldKinds.sequence,
+				//                     types: new Set([
+				//                         // TODO: Which type do we use for characters?
+				//                     ]),
+				//                 },
+				//             ],
+				//         ]),
+				//         globalFields: new Set(),
+				//         extraLocalFields: emptyField,
+				//         extraGlobalFields: false,
+				//         value: ValueSchema.Nothing,
+				//     };
+				// } else {
+				let valueType: ValueSchema;
+				// if (context.isEnum) {
+				//     valueType = ValueSchema.Number;
+				if (context.typeid.startsWith("Reference<")) {
+					valueType = ValueSchema.String;
+				} else if (booleanTypes.has(context.typeid)) {
+					valueType = ValueSchema.Boolean;
+				} else if (numberTypes.has(context.typeid)) {
+					valueType = ValueSchema.Number;
+				} else if (context.typeid === "String") {
+					valueType = ValueSchema.String;
+				} else if (context.typeid === "Enum") {
+					valueType = ValueSchema.Number;
+				} else {
+					throw new Error(`Unknown primitive typeid: ${context.typeid}`);
+				}
+
+				typeSchema = {
+					localFields: new Map(),
+					globalFields: new Set(),
+					extraLocalFields: emptyField,
+					extraGlobalFields: false,
+					value: valueType,
+				};
+				// }
+			} else {
+				if (context.typeid === "NodeProperty") {
+					typeSchema = {
+						localFields: new Map(),
+						globalFields: new Set(),
+						extraLocalFields: {
+							kind: OptionalFieldKind,
+						},
+						extraGlobalFields: false,
+						value: ValueSchema.Nothing,
+					};
+				} else {
+					const localFields = new Map<LocalFieldKey, FieldSchema>();
+					const inheritanceChain = PropertyFactory.getAllParentsForTemplate(
+						context.typeid,
+					);
+					inheritanceChain.push(context.typeid);
+
+					for (const typeIdInInheritanceChain of inheritanceChain) {
+						if (typeIdInInheritanceChain === "NodeProperty") {
+							continue;
+						}
+
+						const schema = PropertyFactory.getTemplate(typeIdInInheritanceChain);
+						if (schema === undefined) {
+							throw new Error(
+								`Unknown typeid referenced: ${typeIdInInheritanceChain}`,
+							);
+						}
+						for (const property of schema.properties) {
+							if (property.properties && !isIgnoreNestedProperties(property.typeid)) {
+								// TODO: Handle nested properties
+							} else {
+								let currentTypeid = property.typeid;
+								if (property.context && property.context !== "single") {
+									currentTypeid = `${property.context}<${property.typeid || ""}>`;
+								}
+								const fieldKey: LocalFieldKey = brand(property.id);
+								if (!localFields.has(fieldKey)) {
+									localFields.set(fieldKey, {
+										kind: property.optional
+											? OptionalFieldKind
+											: ValueFieldKind,
+										types: new Set([currentTypeid]),
+									});
+								} else {
+									const types = localFields.get(fieldKey)?.types ?? fail("never");
+									localFields.set(fieldKey, {
+										kind: property.optional
+											? OptionalFieldKind
+											: ValueFieldKind,
+										types: new Set([...types, currentTypeid]),
+									});
+								}
+							}
+						}
+					}
+
+					typeSchema = {
+						localFields,
+						globalFields: new Set(),
+						extraLocalFields: PropertyFactory.inheritsFrom(
+							context.typeid,
+							"NodeProperty",
+						)
+							? { kind: OptionalFieldKind }
+							: emptyField,
+						extraGlobalFields: false,
+						value: ValueSchema.Nothing,
+					};
+				}
+			}
+		} else {
+			const kind: FieldKindIdentifier =
+				context.context === "array" ? SequenceFieldKind : OptionalFieldKind;
+
+			const fieldType = {
+				kind,
+				types: context.types ?? new Set([context.typeid]),
+			};
+			switch (context.context) {
+				case "map":
+				case "set":
+					typeSchema = {
+						localFields: new Map(),
+						globalFields: new Set(),
+						extraLocalFields: fieldType,
+						extraGlobalFields: false,
+						value: ValueSchema.Serializable,
+					};
+
+					break;
+				case "array":
+					typeSchema = {
+						localFields: new Map<LocalFieldKey, FieldSchema>([[EmptyKey, fieldType]]),
+						globalFields: new Set(),
+						extraLocalFields: emptyField,
+						extraGlobalFields: false,
+						value: ValueSchema.Nothing,
+					};
+					break;
+				default:
+					throw new Error(`Unknown context in typeid: ${context.context}`);
+			}
+		}
+
+		treeSchema.set(referencedTypeId, typeSchema);
+	}
+	const fullSchemaData: SchemaData = {
+		treeSchema,
+		globalFieldSchema: new Map([[rootFieldKey, rootFieldSchema]]),
+	};
+	return fullSchemaData;
+}
+
+// Concepts currently not mapped / represented in the compiled schema:
+//
+// * Annotations
+// * Length constraints for arrays / strings
+// * Constants
+// * Values for enums
+// * Default values

--- a/experimental/PropertyDDS/packages/property-dds/src/test/llsSchemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/llsSchemaConverter.spec.ts
@@ -1,0 +1,113 @@
+/* eslint-disable import/no-internal-modules */
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { PropertyFactory } from "@fluid-experimental/property-properties";
+import { defaultSchemaPolicy, FieldSchema, SchemaData } from "@fluid-internal/tree";
+import { brand } from "@fluid-internal/tree/dist/util/brand";
+import { expect } from "chai";
+import { convertSchemaToSharedTreeLls } from "../sharedtree/llsSchemaConverter";
+
+describe("LlsSchemaConverter", () => {
+	let schemaData: SchemaData;
+	it("Conversion", () => {
+		register();
+		const tableSdc: any = brand("Test:Table-1.0.0");
+		const [, OptionalFieldKind] = defaultSchemaPolicy.fieldKinds.keys();
+
+		function getRootFieldSchema(): FieldSchema {
+			return {
+				kind: OptionalFieldKind,
+				types: new Set([tableSdc]),
+			};
+		}
+		const fieldSchema: FieldSchema = getRootFieldSchema();
+		schemaData = convertSchemaToSharedTreeLls(defaultSchemaPolicy, fieldSchema);
+	});
+	it("Missing Refs", () => {
+		checkMissingRefs(schemaData);
+	});
+});
+
+function register() {
+	PropertyFactory.register({
+		typeid: "Test:Cell-1.0.0",
+		properties: [{ id: "value", typeid: "Uint64" }],
+	});
+
+	PropertyFactory.register({
+		typeid: "Test:Importance-1.0.0",
+		properties: [{ id: "value", typeid: "Uint64" }],
+	});
+
+	PropertyFactory.register({
+		typeid: "Test:RowInfo-1.0.0",
+		properties: [{ id: "value", typeid: "Uint64" }],
+	});
+
+	PropertyFactory.register({
+		typeid: "Test:Row-1.0.0",
+		properties: [{ id: "cells", typeid: "Test:Cell-1.0.0", context: "array" }],
+	});
+
+	PropertyFactory.register({
+		typeid: "Test:ExtendedRow-1.0.0",
+		properties: [
+			{ id: "cells", typeid: "Test:Cell-1.0.0", context: "array" },
+			{ id: "info", typeid: "Test:RowInfo-1.0.0", context: "map" },
+			{ id: "importance", typeid: "Test:Importance-1.0.0", context: "map" },
+		],
+	});
+
+	PropertyFactory.register({
+		typeid: "Test:Table-1.0.0",
+		properties: [
+			{ id: "rows", typeid: "Test:Row-1.0.0", context: "array" },
+			{ id: "width", typeid: "Uint8" },
+			{ id: "extendedRows", typeid: "Test:ExtendedRow-1.0.0", context: "array" },
+			{
+				id: "encoding",
+				typeid: "Enum",
+				properties: [
+					{
+						id: "none",
+						value: 1,
+					},
+					{
+						id: "utf8",
+						value: 2,
+					},
+					{
+						id: "base64",
+						value: 3,
+					},
+				],
+			},
+			{ id: "height", typeid: "Uint8" },
+		],
+	});
+}
+
+function checkMissingRefs(schemaData) {
+	const schemaMap = schemaData.treeSchema;
+	const schemaTypesSet = new Set<string>();
+	let keysIter = schemaMap.keys();
+	for (const key of keysIter) {
+		schemaTypesSet.add(key);
+	}
+	keysIter = schemaMap.keys();
+	for (const key of keysIter) {
+		const value = schemaMap.get(key);
+		value?.localFields.forEach((field) => {
+			if (field.types) {
+				field.types.forEach((type) => {
+					if (!schemaTypesSet.has(type.toString())) {
+						expect.fail(`Missing type ${type.toString()} in schema`);
+					}
+				});
+			}
+		});
+	}
+}

--- a/experimental/PropertyDDS/packages/property-dds/src/test/llsSchemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/llsSchemaConverter.spec.ts
@@ -8,7 +8,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable import/no-internal-modules */
 
-
 import { PropertyFactory } from "@fluid-experimental/property-properties";
 import { defaultSchemaPolicy, FieldSchema, SchemaData, ValueSchema } from "@fluid-internal/tree";
 import { brand } from "@fluid-internal/tree/dist/util/brand";
@@ -125,7 +124,7 @@ function checkMissingRefs(schemaData) {
 			if (field.types) {
 				field.types.forEach((type) => {
 					if (!schemaTypesSet.has(type.toString())) {
-						expect.fail(`Missing type ${type.toString()} in schema`);
+						expect.fail(`Missing type ${type.toString()} in schema at the type ${key} field ${field.name}`);
 					}
 				});
 			}
@@ -135,16 +134,17 @@ function checkMissingRefs(schemaData) {
 
 function checkInheritanceTranslation(schemaData) {
 	const schemaMap = schemaData.treeSchema;
-	const table = schemaMap.get("Test:Table-1.0.0");
-	expect(table).to.not.be.undefined;
-	expect(table?.localFields).to.not.be.undefined;
-	const rows = table?.localFields.get("rows");
-	expect(rows).to.not.be.undefined;
-	expect(rows?.types).to.not.be.undefined;
+	const row = schemaMap.get("array<Test:Row-1.0.0>");
+	expect(row).to.not.be.undefined;
+	expect(row?.localFields).to.not.be.undefined;
+	const field = row?.localFields.get("");
+	expect(field).to.not.be.undefined;
+	expect(field?.types).to.not.be.undefined;
 	// expect.fail(" : " + Array.from(rows?.types) + " : " + Array.from(rows?.types).length);
-	expect(rows?.types?.has("array<Test:Row-1.0.0>")).to.be.true;
-	expect(rows?.types?.has("array<Test:ExtendedRow-1.0.0>")).to.be.true;
-	expect(rows?.types?.has("array<Test:OtherExtendedRow-1.0.0>")).to.be.true;
+    const types = field?.types;
+	expect(types?.has("Test:Row-1.0.0")).to.be.true;
+	expect(types?.has("Test:ExtendedRow-1.0.0")).to.be.true;
+	expect(types?.has("Test:OtherExtendedRow-1.0.0")).to.be.true;
 
 	//	expect.fail(mapToObject(schemaMap));
 }
@@ -170,7 +170,7 @@ function checkTable(schemaData, table) {
 	expect(table).to.not.be.undefined;
 	expect(table?.localFields).to.not.be.undefined;
 	const extendedRows = table?.localFields.get("extendedRows");
-    checkExtendedRows(schemaData, extendedRows);
+	checkExtendedRows(schemaData, extendedRows);
 }
 
 function checkExtendedRows(schemaData, extendedRows) {
@@ -186,23 +186,14 @@ function checkInfo(schemaData, info) {
 	expect(info?.types).to.not.be.undefined;
 	expect(info?.types?.has("map<Test:RowInfo-1.0.0>")).to.be.true;
 	const infoType = schemaData.treeSchema.get("Test:RowInfo-1.0.0");
-    expect(infoType).to.not.be.undefined;
-    expect(infoType?.localFields).to.not.be.undefined;
-    const uint64 = schemaData.treeSchema.get("Test:RowInfo-1.0.0");
-    checkUint64(schemaData, uint64);
+	expect(infoType).to.not.be.undefined;
+	expect(infoType?.localFields).to.not.be.undefined;
+	const uint64 = schemaData.treeSchema.get("Test:RowInfo-1.0.0");
+	checkUint64(schemaData, uint64);
 }
 
 function checkUint64(schemaData, uint64) {
-    expect(uint64).to.not.be.undefined;
-    const uint64Type = schemaData.treeSchema.get("Uint64");
-    expect(uint64Type.value === ValueSchema.Number).to.be.true;
-
+	expect(uint64).to.not.be.undefined;
+	const uint64Type = schemaData.treeSchema.get("Uint64");
+	expect(uint64Type.value === ValueSchema.Number).to.be.true;
 }
-
-
-
-
-
-
-
-

--- a/experimental/PropertyDDS/packages/property-dds/src/test/llsSchemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/llsSchemaConverter.spec.ts
@@ -108,6 +108,14 @@ function register() {
 			},
 		],
 	});
+
+    PropertyFactory.register({
+		typeid: "Test:DescribedTable-1.0.0",
+        inherits: ["Test:Table-1.0.0"],
+		properties: [
+			{ id: "description", typeid: "String"  },
+        ]
+	});
 }
 
 function checkMissingRefs(schemaData) {

--- a/experimental/PropertyDDS/packages/property-dds/src/test/llsSchemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/llsSchemaConverter.spec.ts
@@ -109,12 +109,10 @@ function register() {
 		],
 	});
 
-    PropertyFactory.register({
+	PropertyFactory.register({
 		typeid: "Test:DescribedTable-1.0.0",
-        inherits: ["Test:Table-1.0.0"],
-		properties: [
-			{ id: "description", typeid: "String"  },
-        ]
+		inherits: ["Test:Table-1.0.0"],
+		properties: [{ id: "description", typeid: "String" }],
 	});
 }
 
@@ -132,7 +130,11 @@ function checkMissingRefs(schemaData) {
 			if (field.types) {
 				field.types.forEach((type) => {
 					if (!schemaTypesSet.has(type.toString())) {
-						expect.fail(`Missing type ${type.toString()} in schema at the type ${key} field ${field.name}`);
+						expect.fail(
+							`Missing type ${type.toString()} in schema at the type ${key} field ${
+								field.name
+							}`,
+						);
 					}
 				});
 			}
@@ -149,7 +151,7 @@ function checkInheritanceTranslation(schemaData) {
 	expect(field).to.not.be.undefined;
 	expect(field?.types).to.not.be.undefined;
 	// expect.fail(" : " + Array.from(rows?.types) + " : " + Array.from(rows?.types).length);
-    const types = field?.types;
+	const types = field?.types;
 	expect(types?.has("Test:Row-1.0.0")).to.be.true;
 	expect(types?.has("Test:ExtendedRow-1.0.0")).to.be.true;
 	expect(types?.has("Test:OtherExtendedRow-1.0.0")).to.be.true;

--- a/experimental/PropertyDDS/packages/property-properties/src/index.d.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/index.d.ts
@@ -1309,6 +1309,10 @@ declare module "@fluid-experimental/property-properties" {
 			 */
 			register(in_input: PropertyTemplate | object | string | any[]): void;
 			/**
+			 * Returns the array of the names of the registered types.
+			 */
+			listRegisteredTypes(): string[];
+			/**
 			 * Recursively parses the object of the specified type and returns the created
 			 * array of PropertySets Templates. It does the same thing as the registerFrom()
 			 * function, but it returns the array of templates instead of registering them.

--- a/experimental/PropertyDDS/packages/property-properties/src/index.d.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/index.d.ts
@@ -2274,6 +2274,8 @@ declare module "@fluid-experimental/property-properties" {
 			 */
 			public extractDependencies(): Array<any>;
 
+			public static extractDependencies(template: PropertyTemplateType): Array<string>;
+
 			constants: any[];
 
 			context: string;

--- a/experimental/PropertyDDS/packages/property-properties/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/index.ts
@@ -22,6 +22,7 @@ import { ValueArrayProperty } from "./properties/valueArrayProperty";
 import { ValueMapProperty } from "./properties/valueMapProperty";
 import { ValueProperty } from "./properties/valueProperty";
 import { enableValidations } from "./enableValidations";
+import { PropertyTemplate } from "./propertyTemplate";
 
 export {
 	PropertyFactory,
@@ -44,4 +45,5 @@ export {
 	ValueMapProperty,
 	ValueProperty,
 	enableValidations,
+	PropertyTemplate,
 };

--- a/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
@@ -593,6 +593,13 @@ class PropertyFactory {
 			}
 		}
 	}
+	/**
+	 * Returns the array of the names of the registered types.
+	 * @returns {Array.<string>} Array of the names of the registered types.
+	 */
+	listRegisteredTypes() {
+		return Array.from(this._localPrimitivePropertiesAndTemplates.keys);
+	}
 
 	/**
 	 * Recursively parses the object of the specified type and returns the created


### PR DESCRIPTION


## Description

This is the initial implementation of the schema converter from Property DDS schema to SharedTree LLS schema.
It is based on the code at
https://github.com/sharptrip/FluidFramework/blob/editable-tree-inspector-with-transaction-handling/experimental/PropertyDDS/examples/schemas/src/schemaConverter.ts

Following are the changes and additions to the original code 

### Fields are never merged
Two fields of the Array context are not merged to one Empty Key field with both type1 and type2 instances possible. All fields are generated in the LLS schema as they were present in PDDS schema

```
        "filed1": {"kind": "Value", "types": ["array<Type1-1.0.0>"]},
        "field2": {"kind": "Value", "types": ["array<Type2-1.0.0>"]},
```

### Enums
Enums are supported and converted to the type Enum which is the node containing the number value as follows

```
    "Enum": {
      "localFields": {},
      "globalFields": [],
      "extraLocalFields": {"kind": "Forbidden", "types": []},
      "extraGlobalFields": false,
      "value": 1
    }
```

### OO Inheritance

Inheritance within the class hierarchy is covered by union of types. For example, if we have the types `Ext2-1.0.0 inherits from Ext1-1.0.0 inherits from Base-1.0.0` and the Base is configured for the property `fieldWithInherits`, we get following schema structure

```
        "fieldWithInherits": {
          "kind": "Value",
          "types": [
            "Base-1.0.0",
            "Ext1-1.0.0",
            "Ext2-1.0.0"
          ]
        }
```


## Review Notes

Reviewers:
@dstanesc @sharptrip @ruiterr 











 
