### PR TITLE
Update property-interop package

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -246,9 +246,6 @@ export function createEmitter<E extends Events<E>>(noListeners?: NoListenersCall
 export const createField: unique symbol;
 
 // @alpha
-export function createSchemaRepository(schemaPolicy?: FullSchemaPolicy, data?: SchemaData): StoredSchemaRepository;
-
-// @alpha
 export interface CrossFieldManager<T = unknown> {
     get(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId, addDependency: boolean): T | undefined;
     getOrCreate(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId, newValue: T, invalidateDependents: boolean): T;

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
@@ -36,15 +36,15 @@
 	},
 	"devDependencies": {
 		"@fluidframework/build-common": "^1.1.0",
-		"@rushstack/eslint-config": "^2.5.1",
 		"@types/jest": "22.2.3",
-		"@types/node": "^14.18.36",
-		"concurrently": "^6.2.0",
+		"@types/node": "^14.18.38",
+		"concurrently": "^7.6.0",
 		"eslint": "~8.6.0",
+		"eslint-config-prettier": "~8.5.0",
 		"jest": "^26.6.3",
 		"jest-junit": "^10.0.0",
 		"prettier": "~2.6.2",
-		"rimraf": "^2.6.2",
+		"rimraf": "^4.4.0",
 		"ts-jest": "^26.4.4",
 		"typescript": "~4.5.5"
 	},
@@ -60,9 +60,6 @@
 	},
 	"typeValidation": {
 		"disabled": true,
-		"version": "2.0.0-internal.2.2.0",
-		"baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-		"baselineVersion": "2.0.0-internal.2.1.0",
 		"broken": {}
 	}
 }

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/index.ts
@@ -3,4 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { convertPropertyToSharedTreeStorageSchema, addComplexTypeToSchema } from "./schemaConverter";
+export {
+	convertPropertyToSharedTreeStorageSchema,
+	addComplexTypeToSchema,
+} from "./schemaConverter";

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { convertPropertyToSharedTreeStorageSchema } from "./schemaConverter";
+export { convertPropertyToSharedTreeStorageSchema, addComplexTypeToSchema } from "./schemaConverter";

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -387,7 +387,9 @@ const allowedCollectionContexts = new Set(["array", "map", "set"]);
  * The resulting type added to the schema will have a name
  * in the PropertyDDS format `context<typeName>`.
  *
- * Be aware, that it creates a shallow copy of the `SchemaDataAndPolicy`.
+ * Be aware, that using this function might be very unperformant
+ * as it reads all types registered in PropertyDDS schema
+ * and creates a shallow copy of the `SchemaDataAndPolicy`.
  */
 export function addComplexTypeToSchema(
 	fullSchemaData: SchemaDataAndPolicy,

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/tableExampleSchemaConverter.spec.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/test/tableExampleSchemaConverter.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 import { PropertyFactory } from "@fluid-experimental/property-properties";
 import {
-	createSchemaRepository,
 	ValueSchema,
 	brand,
 	EmptyKey,
@@ -95,12 +94,10 @@ describe("LlsSchemaConverter", () => {
 	beforeAll(registerPropertySchemas);
 
 	it("Enum", () => {
-		const schemaRepository = createSchemaRepository();
-		convertPropertyToSharedTreeStorageSchema(
-			schemaRepository,
+		const fullSchemaData = convertPropertyToSharedTreeStorageSchema(
 			fieldSchema(FieldKinds.optional, [tableTypeName]),
 		);
-		const table = lookupTreeSchema(schemaRepository, tableTypeName);
+		const table = lookupTreeSchema(fullSchemaData, tableTypeName);
 		assert(table !== undefined);
 		const encoding = table.localFields.get(brand("encoding"));
 		assert(encoding !== undefined);
@@ -109,14 +106,12 @@ describe("LlsSchemaConverter", () => {
 	});
 
 	it("Missing Refs", () => {
-		const schemaRepository = createSchemaRepository();
-		convertPropertyToSharedTreeStorageSchema(
-			schemaRepository,
+		const fullSchemaData = convertPropertyToSharedTreeStorageSchema(
 			fieldSchema(FieldKinds.optional, [tableTypeName]),
 		);
-		const typeNames = new Set(schemaRepository.treeSchema.keys());
+		const typeNames = new Set(fullSchemaData.treeSchema.keys());
 		for (const typeName of typeNames) {
-			const treeSchema = lookupTreeSchema(schemaRepository, typeName);
+			const treeSchema = lookupTreeSchema(fullSchemaData, typeName);
 			assert(treeSchema !== undefined);
 			treeSchema.localFields.forEach((field, fieldKey) => {
 				if (field.types) {
@@ -140,12 +135,10 @@ describe("LlsSchemaConverter", () => {
 	});
 
 	it("Check Structure", () => {
-		const schemaRepository = createSchemaRepository();
-		convertPropertyToSharedTreeStorageSchema(
-			schemaRepository,
+		const fullSchemaData = convertPropertyToSharedTreeStorageSchema(
 			fieldSchema(FieldKinds.optional, [tableTypeName]),
 		);
-		const table = lookupTreeSchema(schemaRepository, tableTypeName);
+		const table = lookupTreeSchema(fullSchemaData, tableTypeName);
 		assert(table !== undefined);
 		assert(table.localFields !== undefined);
 
@@ -155,7 +148,7 @@ describe("LlsSchemaConverter", () => {
 		assert(extendedRows.types.has(brand("array<Test:ExtendedRow-1.0.0>")));
 
 		const extendedRowsSchema = lookupTreeSchema(
-			schemaRepository,
+			fullSchemaData,
 			brand("Test:ExtendedRow-1.0.0"),
 		);
 		assert(extendedRowsSchema !== undefined);
@@ -163,7 +156,7 @@ describe("LlsSchemaConverter", () => {
 		assert(info !== undefined);
 		assert(info.types !== undefined);
 		assert(info.types.has(brand("map<Test:RowInfo-1.0.0>")));
-		const infoType = lookupTreeSchema(schemaRepository, brand("Test:RowInfo-1.0.0"));
+		const infoType = lookupTreeSchema(fullSchemaData, brand("Test:RowInfo-1.0.0"));
 		assert(infoType !== undefined);
 
 		const uint64 = infoType.localFields.get(brand("value"));
@@ -171,17 +164,15 @@ describe("LlsSchemaConverter", () => {
 		assert(uint64.types !== undefined);
 		expect(uint64.types.has(brand("Uint64"))).toBeTruthy();
 		assert(uint64.types.has(brand("Uint64")));
-		const uint64Type = lookupTreeSchema(schemaRepository, brand("Uint64"));
+		const uint64Type = lookupTreeSchema(fullSchemaData, brand("Uint64"));
 		assert(uint64Type.value === ValueSchema.Number);
 	});
 
 	it("Inheritance Translation", () => {
-		const schemaRepository = createSchemaRepository();
-		convertPropertyToSharedTreeStorageSchema(
-			schemaRepository,
+		const fullSchemaData = convertPropertyToSharedTreeStorageSchema(
 			fieldSchema(FieldKinds.optional, [tableTypeName]),
 		);
-		const row = lookupTreeSchema(schemaRepository, brand("array<Test:Row-1.0.0>"));
+		const row = lookupTreeSchema(fullSchemaData, brand("array<Test:Row-1.0.0>"));
 		assert(row !== undefined);
 		assert(row.localFields !== undefined);
 		const field = row.localFields.get(EmptyKey);

--- a/packages/dds/tree/src/feature-libraries/defaultSchema.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultSchema.ts
@@ -3,16 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	fieldSchema,
-	emptyMap,
-	emptySet,
-	ValueSchema,
-	TreeSchema,
-	InMemoryStoredSchemaRepository,
-	StoredSchemaRepository,
-	SchemaData,
-} from "../core";
+import { fieldSchema, emptyMap, emptySet, ValueSchema, TreeSchema } from "../core";
 import { value, forbidden, fieldKinds } from "./defaultFieldKinds";
 import { FullSchemaPolicy } from "./modular-schema";
 
@@ -52,14 +43,3 @@ export const defaultSchemaPolicy: FullSchemaPolicy = {
 	defaultTreeSchema: neverTree,
 	defaultGlobalFieldSchema: emptyField,
 };
-
-/**
- * Helper for building {@link StoredSchemaRepository}.
- * @alpha
- */
-export function createSchemaRepository(
-	schemaPolicy = defaultSchemaPolicy,
-	data?: SchemaData,
-): StoredSchemaRepository {
-	return new InMemoryStoredSchemaRepository(schemaPolicy, data);
-}

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -72,13 +72,7 @@ export { singleTextCursor, jsonableTreeFromCursor } from "./treeTextCursor";
 import * as SequenceField from "./sequence-field";
 export { SequenceField };
 
-export {
-	defaultSchemaPolicy,
-	emptyField,
-	neverField,
-	neverTree,
-	createSchemaRepository,
-} from "./defaultSchema";
+export { defaultSchemaPolicy, emptyField, neverField, neverTree } from "./defaultSchema";
 
 export {
 	ChangesetLocalId,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -202,7 +202,6 @@ export {
 	isWritableArrayLike,
 	isContextuallyTypedNodeDataObject,
 	defaultSchemaPolicy,
-	createSchemaRepository,
 	jsonableTreeFromCursor,
 	PrimitiveValue,
 	IDefaultEditBuilder,


### PR DESCRIPTION
This PR introduces the following changes:
- bumps dependency versions (based on other fluid packages)
- removes version validation (as for other experimental packages)
- removes `createSchemaRepository` and all related code - schema converter works without repository as it should
- adds `Reference` to the list of primitive types
- unconditionally creates array and map types for all primitive types and `NodeProperty` (including it's children)